### PR TITLE
fix: add the "Add to MetaMask" button to the doc

### DIFF
--- a/en/documentation/getting-started/resources/resources.mdx
+++ b/en/documentation/getting-started/resources/resources.mdx
@@ -2,58 +2,99 @@
 title: "Resources"
 ---
 
-| Resources | URL |
-| -------- | ------------------------------------- |
-| **Mainnet** | https://rpc.mainnet.axiomesh.io (not yet online)|
-| **Aries Testnet** | https://rpc1.aries.axiomesh.io|
-| **Aries AXMScan**| https://scan.aries.axiomesh.io |
-| **Aries Faucet**   | https://faucet.aries.axiomesh.io |
+export async function addTestingNetwork() {
+  const confirmed = window.confirm(
+    "Are you sure you want to add AxiomLedger-Testnet to MetaMask?"
+  );
+  if (!confirmed) {
+    return;
+  }
+  const ethereum = window.ethereum;
+  if (!ethereum) {
+    alert("Please install MetaMask first.");
+    return;
+  }
+  const networkConfig = {
+    method: "wallet_addEthereumChain",
+    params: [
+      {
+        chainId: "0x5b73",
+        rpcUrls: ["https://rpc1.aries.axiomesh.io"],
+        chainName: "AxiomLedger-Testnet",
+        nativeCurrency: {
+          name: "AxiomLedger",
+          symbol: "AXM",
+          decimals: 18,
+        },
+        blockExplorerUrls: ["https://scan.aries.axiomesh.io"],
+      },
+    ],
+  };
+  try {
+    await window.ethereum.request(networkConfig);
+    alert("AxiomLedger-Testnet has been added to MetaMask.");
+  } catch (error) {
+    alert(error.message);
+  }
+}
 
+| Resources         | URL                                              | Action                                                       |
+| ----------------- | ------------------------------------------------ | ------------------------------------------------------------ |
+| **Mainnet**       | https://rpc.mainnet.axiomesh.io (not yet online) | N/A                                                          |
+| **Aries Testnet** | https://rpc1.aries.axiomesh.io                   | <button onClick={addTestingNetwork}>Add to MetaMask</button> |
+| **Aries AXMScan** | https://scan.aries.axiomesh.io                   | N/A                                                          |
+| **Aries Faucet**  | https://faucet.aries.axiomesh.io                 | N/A                                                          |
 
 ## Network
+
 Chains refer to various distinct AxiomLedger environments where development, testing, or production use cases can take place.
 
 AxiomLedgers accounts can be used across different chains, but it's important to note that account balances and transaction histories do not transfer beyond the AxiomLedger mainnet. Understanding the available networks and how to obtain testnet AXM for experimentation can be useful when conducting tests. Generally, for security reasons, it's not recommended to use mainnet accounts on testnets, and vice versa.
 
-
 ### Mainnet
+
 The mainnet refers to the primary AxiomLedger blockchain within the broader ecosystem, where all transactions with real value take place on its decentralized ledger.
 
 The AXM price that the general public and exchanges deal with corresponds to the AXM on the mainnet. Currently AxiomLedger is still yet in beta and has not released its mainnet.
 
 ### Testnet
+
 The public testnets are networks that simulate the ecosystem environment, where protocol developers and smart contract developers can use them to test protocol upgrades and smart contracts that haven't been deployed to the mainnet yet. You can think of them as simulations of the production and assembly servers.
 Before deploying to the mainnet, you should test any contract code you've written on a testnet. In decentralized applications that integrate with existing smart contracts, most projects deploy replicas to a testnet.
 
-Interacting with AxiomLedger requires AXM in reality. If you are interested in experimenting with AxiomLedger, you can obtain free testnet `AXM` on [Faucet](https://faucet.aries.axiomesh.io), a web application where you can request AXM to be sent to an address, allowing you to explore the platform without any risks. 
+Interacting with AxiomLedger requires AXM in reality. If you are interested in experimenting with AxiomLedger, you can obtain free testnet `AXM` on [Faucet](https://faucet.aries.axiomesh.io), a web application where you can request AXM to be sent to an address, allowing you to explore the platform without any risks.
 
 AXM on the testnet has no real value, it is meant only for experimentation purposes on the AxiomLedger testnet.
 
 ### Connect to the Testnet
-AxiomLedger is an EVM-compatible blockchain. Once you have an Ethereum address, you can connect to AxiomLedger testnet using popular wallets (such as Metamask ) or SDK. 
-If you are using Metamask to connect to the AxiomLedger for the first time, you will need to add the RPC address, chain ID, token symbol, and the other information to the network list. 
+
+AxiomLedger is an EVM-compatible blockchain. Once you have an Ethereum address, you can connect to AxiomLedger testnet using popular wallets (such as Metamask ) or SDK.
+If you are using Metamask to connect to the AxiomLedger for the first time, you will need to add the RPC address, chain ID, token symbol, and the other information to the network list.
+
 - RPC address of AxiomLedger testnet: `https://rpc1.aries.axiomesh.io`
 - Chain ID: `23411`
 - Token symbol: `AXM`
 
 ## Faucet
+
 A faucet is a blockchain tool that drips testnet tokens for free to anyone who requests them.
 
 ### Get Free Tokens
-Testnet token is a testing currency that enables you to test your application before deploying it on the mainnet.  These tokens can be used in place of mainnet tokens on testnets like Aries. You can use these tokens to perform various test transactions on the associated blockchain, including contract deployments, fund transfers, and debugging failed transactions. You can request testnet tokens [here](https://faucet.aries.axiomesh.io).
+
+Testnet token is a testing currency that enables you to test your application before deploying it on the mainnet. These tokens can be used in place of mainnet tokens on testnets like Aries. You can use these tokens to perform various test transactions on the associated blockchain, including contract deployments, fund transfers, and debugging failed transactions. You can request testnet tokens [here](https://faucet.aries.axiomesh.io).
 
 ### Faucet Limitation
+
 You can only obtain once in every 24 hours.
 
-
-
 ## AXMScan
-The [Aries AXMScan](https://scan.aries.axiomesh.io) allows you dive into the activity on the AxiomLedger testnet in great detail, enabling you to view transactions, blocks, wallets, tokens, smart contracts, and statistics. 
 
+The [Aries AXMScan](https://scan.aries.axiomesh.io) allows you dive into the activity on the AxiomLedger testnet in great detail, enabling you to view transactions, blocks, wallets, tokens, smart contracts, and statistics.
 
 ![AXMScan](/en/images/getting-started/AXMScan1.png)
 
 ### Features
+
 With the AXMScan, you can check the details of transactions, blocks, top accounts and verified contracts on each submenu.
 
 ![Submenu](/en/images/getting-started/SubMenu1.png)
@@ -63,6 +104,7 @@ With the AXMScan, you can check the details of transactions, blocks, top account
 ![SearchBar](/en/images/getting-started/SearchBar1.png)
 
 Use the search bar to access data by:
+
 - **Address**: The address of an EOA (Externally Owned Account).
 - **Contract address**: The callable address of a smart contract deployed on AxiomLedger.
 - **Transaction hash**: The unique 66 character identifiers of an executed transaction.


### PR DESCRIPTION
This PR enables users to easily add TestNet to their MetaMask network selection without manually entering a bunch of network information. For details, see the following screenshots:



<img width="689" alt="Screenshot 2023-10-11 at 11 28 57 AM" src="https://github.com/axiomesh/docs/assets/32106111/0dc3d260-ab90-46e7-9b8b-c61b3842f495">
<img width="1172" alt="Screenshot 2023-10-11 at 11 29 09 AM" src="https://github.com/axiomesh/docs/assets/32106111/efa8e54b-9157-492a-bb67-e5893622a228">
<img width="1728" alt="Screenshot 2023-10-11 at 11 29 23 AM" src="https://github.com/axiomesh/docs/assets/32106111/dcf103e8-6e86-419f-999f-c303884d88cc">
<img width="1106" alt="Screenshot 2023-10-11 at 11 29 38 AM" src="https://github.com/axiomesh/docs/assets/32106111/a9c08c1b-8906-4655-941f-1a49aa71c82c">
